### PR TITLE
Add Lockpaw to Useful tools and guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,8 @@ Google's Project Zero series of articles that detail vulnerabilities in the wire
 ### [Ipsw Walkthrough](https://8ksec.io/ipsw-walkthrough-part-1-the-swiss-army-knife-for-ios-macos-security-research/)
 * Part one that covers basic uses
 ### [Mobile CTF challenges](https://8ksec.io/battle/)
+### [Lockpaw](https://github.com/sorkila/lockpaw)
+* macOS menu bar screen guard that locks and unlocks your display with a hotkey. Open source, no telemetry.
 
 ## Remote Access Toolkits
 ### [Empyre](https://github.com/EmpireProject/EmPyre)


### PR DESCRIPTION
[Lockpaw](https://github.com/sorkila/lockpaw) is an open-source macOS menu bar screen guard. Lock and unlock your display with a global hotkey. Built with Swift, MIT licensed, no telemetry.

- 47+ GitHub stars
- Available via Homebrew (`brew tap sorkila/lockpaw && brew install --cask lockpaw`)